### PR TITLE
Pyinstall dxf2png

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Both input and output files are set relative to the script's root directory, i.e
 * Create a virtual environment: `virtualenv -p /usr/bin/python3 cad-mixer`
 * Activate the environment: `source cad-mixer/bin/activate`
 * Install the requirements (PIP is required): `pip install -r requirements.txt`
+* Extra step for ArchLinux: PyInstaller doesn't work on ArchLinux as intended in some cases as mentioned in [this issue here](https://github.com/pyinstaller/pyinstaller/issues/5540). A workaround is provided in a bash script and can be ran simply as `chmod +x arch_pyinstaller.sh && bash arch_pyinstaller.sh`
 * Go to the dxf2png folder: `cd dxf2png`
 * Run the probram: `python main.py`
 * Deactivate the environment when done: `deactivate`

--- a/README.md
+++ b/README.md
@@ -43,14 +43,13 @@ Both input and output files are set relative to the script's root directory, i.e
 ##### Setup with Virtualenv
 * Create a virtual environment: `virtualenv -p /usr/bin/python3 venv`
 * Activate the environment: `source venv/bin/activate`
-* Install the requirements (PIP is required): `pip install -r requirements.txt`
+* Install the requirements (PIP is required): `python setup.py`
 * Deactivate the environment when done: `deactivate`
 
 #### Building the binary executable
 
 This assumes that the dependencies were installed with PIP in a virtual environment (see the **Setup with Virtualenv** section). Conda handles dependencies in a trickier way and this might not work.
 
-* Extra step for ArchLinux: PyInstaller doesn't work on ArchLinux as intended in some cases as mentioned in [this issue here](https://github.com/pyinstaller/pyinstaller/issues/5540). A workaround is provided in a bash script and can be ran simply as `chmod +x arch_pyinstaller.sh && bash arch_pyinstaller.sh`
 * Go to the dxf2png folder (if not there already): `cd dxf2png`
 * Run the installation: `pyinstaller -F -w --paths "./../venv/lib/python3.8/site-packages/" --exclude-module tkinter --onefile -n dxf2png main.py`
 

--- a/README.md
+++ b/README.md
@@ -38,23 +38,29 @@ python main.py --input input.dxf --output output.png
 ```
 Both input and output files are set relative to the script's root directory, i.e. should be located in the same directory.
 
-#### Preparing the environment on Linux
-
-##### Setup with Virtualenv
+#### Automatic installation
 * Create a virtual environment: `virtualenv -p /usr/bin/python3 venv`
 * Activate the environment: `source venv/bin/activate`
-* Install the requirements (PIP is required): `python setup.py`
+* Run the atomatic installer: `python setup.py`
 * Deactivate the environment when done: `deactivate`
-
-#### Building the binary executable
-
-This assumes that the dependencies were installed with PIP in a virtual environment (see the **Setup with Virtualenv** section). Conda handles dependencies in a trickier way and this might not work.
-
-* Go to the dxf2png folder (if not there already): `cd dxf2png`
-* Run the installation: `pyinstaller -F -w --paths "./../venv/lib/python3.8/site-packages/" --exclude-module tkinter --onefile -n dxf2png main.py`
 
 The resulting executable file is placed to the `dist` folder at the same path as `main.py`. It can be used as follows:
 ```sh
 cd dist
 ./dxf2png -i input_file.dxf -o output_file.png
 ```
+
+#### Manual installation
+
+##### Prepare a virtual environment
+* Create a virtual environment: `virtualenv -p /usr/bin/python3 venv`
+* Activate the environment: `source venv/bin/activate`
+* Install the requirements (PIP is required): `pip install -r requirements.txt`
+* Deactivate the environment when done: `deactivate`
+
+##### Building the binary executable
+
+This assumes that the dependencies were installed with PIP in a virtual environment (see the **Setup with Virtualenv** section). Conda handles dependencies in a trickier way and this might not work.
+
+* Go to the dxf2png folder (if not there already): `cd dxf2png`
+* Run the installation: `pyinstaller -F -w --paths "./../venv/lib/python3.8/site-packages/" --exclude-module tkinter --onefile -n dxf2png main.py`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This assumes that the dependencies were installed with PIP in a virtual environm
 
 * Extra step for ArchLinux: PyInstaller doesn't work on ArchLinux as intended in some cases as mentioned in [this issue here](https://github.com/pyinstaller/pyinstaller/issues/5540). A workaround is provided in a bash script and can be ran simply as `chmod +x arch_pyinstaller.sh && bash arch_pyinstaller.sh`
 * Go to the dxf2png folder (if not there already): `cd dxf2png`
-* Run the installation: `pyinstaller --paths="./../venv/lib" -n dxf2png --exclude-module tkinter --onefile main.py`
+* Run the installation: `pyinstaller -F -w --paths "./../venv/lib/python3.8/site-packages/" --exclude-module tkinter --onefile -n dxf2png main.py`
 
 The resulting executable file is placed to the `dist` folder at the same path as `main.py`. It can be used as follows:
 ```sh

--- a/README.md
+++ b/README.md
@@ -46,12 +46,6 @@ Both input and output files are set relative to the script's root directory, i.e
 * Install the requirements (PIP is required): `pip install -r requirements.txt`
 * Deactivate the environment when done: `deactivate`
 
-##### Setup with Anaconda
-This assumes that you have the Conda package installed.
-* Create a virtual environment: `conda env create --name cad-mixer -f environment.yml`
-* Activate the environment: `conda activate cad-mixer`
-* Deactivate the environment when done: `conda deactivate`
-
 #### Building the binary executable
 
 This assumes that the dependencies were installed with PIP in a virtual environment (see the **Setup with Virtualenv** section). Conda handles dependencies in a trickier way and this might not work.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,8 @@ If you want to contribute to the project please join our discord server and let 
 
 To add a contribution make a fork of the project, notify which issue you are working on and then when ready make a Pull Request.
 
-
 ## Communication
 The communication for this project happens on our [CAD Mixer Community Discord Server](https://discord.gg/3ErkNJZmsa) you can join by clicking on this invite: https://discord.gg/3ErkNJZmsa
-
 
 ## CI/CD
 We use Github Actions to triggers some continuous integration steps. So far we have the following:
@@ -40,25 +38,22 @@ python main.py --input input.dxf --output output.png
 ```
 Both input and output files are set relative to the script's root directory, i.e. should be located in the same directory.
 
-#### Setup with Virtualenv
+#### Preparing the environment
+##### Setup with Virtualenv
 * Create a virtual environment: `virtualenv -p /usr/bin/python3 cad-mixer`
 * Activate the environment: `source cad-mixer/bin/activate`
 * Install the requirements (PIP is required): `pip install -r requirements.txt`
-* Go to the dxf2png folder: `cd dxf2png`
-* Run the probram: `python main.py`
 * Deactivate the environment when done: `deactivate`
 
-#### Setup with Anaconda
+##### Setup with Anaconda
 This assumes that you have the Conda package installed.
 * Create a virtual environment: `conda env create --name cad-mixer -f environment.yml`
 * Activate the environment: `conda activate cad-mixer`
-* Go to the dxf2png folder: `cd dxf2png`
-* Run the program: `python main.py`
 * Deactivate the environment when done: `conda deactivate`
 
-### Building the binary executable
+#### Building the binary executable
 
-This assumes that the dependencies were installed with PIP in a virtual environment. Conda handles dependencies in a trickier way and this might not work.
+This assumes that the dependencies were installed with PIP in a virtual environment (see the **Setup with Virtualenv** section). Conda handles dependencies in a trickier way and this might not work.
 
 * Extra step for ArchLinux: PyInstaller doesn't work on ArchLinux as intended in some cases as mentioned in [this issue here](https://github.com/pyinstaller/pyinstaller/issues/5540). A workaround is provided in a bash script and can be ran simply as `chmod +x arch_pyinstaller.sh && bash arch_pyinstaller.sh`
 * Go to the dxf2png folder (if not there already): `cd dxf2png`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This assumes that the dependencies were installed with PIP in a virtual environm
 
 * Extra step for ArchLinux: PyInstaller doesn't work on ArchLinux as intended in some cases as mentioned in [this issue here](https://github.com/pyinstaller/pyinstaller/issues/5540). A workaround is provided in a bash script and can be ran simply as `chmod +x arch_pyinstaller.sh && bash arch_pyinstaller.sh`
 * Go to the dxf2png folder (if not there already): `cd dxf2png`
-* Run the installation: `pyinstaller --paths="./../cad-mixer/lib" -n dxf2png --exclude-module tkinter --onefile main.py`
+* Run the installation: `pyinstaller --paths="./../venv/lib" -n dxf2png --exclude-module tkinter --onefile main.py`
 
 The resulting executable file is placed to the `dist` folder at the same path as `main.py`. It can be used as follows:
 ```sh

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This assumes that the dependencies were installed with PIP in a virtual environm
 
 * Extra step for ArchLinux: PyInstaller doesn't work on ArchLinux as intended in some cases as mentioned in [this issue here](https://github.com/pyinstaller/pyinstaller/issues/5540). A workaround is provided in a bash script and can be ran simply as `chmod +x arch_pyinstaller.sh && bash arch_pyinstaller.sh`
 * Go to the dxf2png folder (if not there already): `cd dxf2png`
-* Run the installation: `pyinstaller -n dxf2png --exclude-module tkinter --onefile main.py`
+* Run the installation: `pyinstaller --paths="./../cad-mixer/lib" -n dxf2png --exclude-module tkinter --onefile main.py`
 
 The resulting executable file is placed to the `dist` folder at the same path as `main.py`. It can be used as follows:
 ```sh

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This assumes that the dependencies were installed with PIP in a virtual environm
 
 * Extra step for ArchLinux: PyInstaller doesn't work on ArchLinux as intended in some cases as mentioned in [this issue here](https://github.com/pyinstaller/pyinstaller/issues/5540). A workaround is provided in a bash script and can be ran simply as `chmod +x arch_pyinstaller.sh && bash arch_pyinstaller.sh`
 * Go to the dxf2png folder (if not there already): `cd dxf2png`
-* Run the installation: `pyinstaller -n "dxf2png" --onefile main.py`
+* Run the installation: `pyinstaller -n dxf2png --exclude-module tkinter --onefile main.py`
 
 The resulting executable file is placed to the `dist` folder at the same path as `main.py`. It can be used as follows:
 ```sh

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Both input and output files are set relative to the script's root directory, i.e
 #### Preparing the environment on Linux
 
 ##### Setup with Virtualenv
-* Create a virtual environment: `virtualenv -p /usr/bin/python3 cad-mixer`
-* Activate the environment: `source cad-mixer/bin/activate`
+* Create a virtual environment: `virtualenv -p /usr/bin/python3 venv`
+* Activate the environment: `source venv/bin/activate`
 * Install the requirements (PIP is required): `pip install -r requirements.txt`
 * Deactivate the environment when done: `deactivate`
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ python main.py --input input.dxf --output output.png
 ```
 Both input and output files are set relative to the script's root directory, i.e. should be located in the same directory.
 
-#### Preparing the environment
+#### Preparing the environment on Linux
+
 ##### Setup with Virtualenv
 * Create a virtual environment: `virtualenv -p /usr/bin/python3 cad-mixer`
 * Activate the environment: `source cad-mixer/bin/activate`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Both input and output files are set relative to the script's root directory, i.e
 * Create a virtual environment: `virtualenv -p /usr/bin/python3 cad-mixer`
 * Activate the environment: `source cad-mixer/bin/activate`
 * Install the requirements (PIP is required): `pip install -r requirements.txt`
-* Extra step for ArchLinux: PyInstaller doesn't work on ArchLinux as intended in some cases as mentioned in [this issue here](https://github.com/pyinstaller/pyinstaller/issues/5540). A workaround is provided in a bash script and can be ran simply as `chmod +x arch_pyinstaller.sh && bash arch_pyinstaller.sh`
 * Go to the dxf2png folder: `cd dxf2png`
 * Run the probram: `python main.py`
 * Deactivate the environment when done: `deactivate`
@@ -56,3 +55,17 @@ This assumes that you have the Conda package installed.
 * Go to the dxf2png folder: `cd dxf2png`
 * Run the program: `python main.py`
 * Deactivate the environment when done: `conda deactivate`
+
+### Building the binary executable
+
+This assumes that the dependencies were installed with PIP in a virtual environment. Conda handles dependencies in a trickier way and this might not work.
+
+* Extra step for ArchLinux: PyInstaller doesn't work on ArchLinux as intended in some cases as mentioned in [this issue here](https://github.com/pyinstaller/pyinstaller/issues/5540). A workaround is provided in a bash script and can be ran simply as `chmod +x arch_pyinstaller.sh && bash arch_pyinstaller.sh`
+* Go to the dxf2png folder (if not there already): `cd dxf2png`
+* Run the installation: `pyinstaller -n "dxf2png" --onefile main.py`
+
+The resulting executable file is placed to the `dist` folder at the same path as `main.py`. It can be used as follows:
+```sh
+cd dist
+./dxf2png -i input_file.dxf -o output_file.png
+```

--- a/arch_pyinstaller.sh
+++ b/arch_pyinstaller.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# This script replaces pyinstaller installed with pip by default with a patched version specifically for pacman distros such as ArchLinux. 
+pip remove pyinstaller
+wget github.com/bwoodsend/pyinstaller/archive/5540.zip
+pip install 5540.zip
+rm 5540.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ezdxf == 0.15.1
 imutils == 0.5.4
-matplotlib == 3.3.4
+matplotlib == 3.0.3
 natsort == 7.1.1
 opencv-python == 4.5.1.48
 pillow == 8.1.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+import pip
+
+_all_ = [
+        "ezdxf == 0.15.1",
+        "imutils == 0.5.4",
+        "matplotlib == 3.0.3",
+        "natsort == 7.1.1",
+        "opencv-python == 4.5.1.48",
+        "pillow == 8.1.0",
+        "pyinstaller == 4.2"
+        ]
+
+
+def install(packages):
+    for package in packages:
+        pip.main(['install', package])
+
+if __name__ == '__main__':
+    import platform
+    import subprocess
+
+    print("Starting the installation")
+    install(_all_) 
+    if "arch" in platform.release():
+        print("The OS is detected to be ArchLinux")
+        # An extra step is required for ArchLinux as PyInstaller
+        # doesn't work on ArchLinux as intended in some cases as
+        # mentioned in this issue here:
+        # https://github.com/pyinstaller/pyinstaller/issues/5540
+        # A workaround is provided in a bash script
+        subprocess.call(['sh', './arch_pyinstaller.sh'])
+    print("The requirements are installed\n" +
+            "Generating an executable file...")
+    #go_to_dxf2png_dir = subprocess.Popen(["cd", "dxf2png"], shell = True)
+    #print(go_to_dxf2png_dir.returncode)
+    exe_generation = subprocess.run(["pyinstaller", "-F", "-w",
+        "--paths", "./../venv/lib/python3.8/site-packages/",
+        "--exclude-module", "tkinter",
+        "--onefile", "-n", "dxf2png",
+        "dxf2png/main.py"])
+    print(exe_generation.returncode)
+    print("Installation successful")


### PR DESCRIPTION
In this pull request the steps for generating the executable binary file for the dxf2png converter with PyInstaller are described in README.md.

There were troubles with making it work on different machines and it appears to work now, on 3 different PCs, but it might be better to test it on more PCs.